### PR TITLE
Fixed bugs related to using oauth with a webclient response object

### DIFF
--- a/src/mediasilo/asset/AssetProxy.php
+++ b/src/mediasilo/asset/AssetProxy.php
@@ -15,7 +15,6 @@ class AssetProxy {
 
     public function __construct($webClient) {
         $this->webClient = $webClient;
-        $this->roleManager = new RoleManager($this->webClient);
     }
 
     /**
@@ -111,8 +110,17 @@ class AssetProxy {
         return $assets;
     }
 
+    private function getRoleManager() {
+        if (isset($this->roleManager)) {
+            return $this->roleManager;
+        } else {
+            $this->roleManager = new RoleManager($this->webClient);
+            return $this->roleManager;
+        }
+    }
+
     private function attachAclToAsset(&$asset) {
-        $role = $this->roleManager->getUserRoleForAsset($asset);
+        $role = $this->getRoleManager()->getUserRoleForAsset($asset);
         $asset->acl = $role->getPermissionGroups();
     }
 

--- a/src/mediasilo/http/WebClient.php
+++ b/src/mediasilo/http/WebClient.php
@@ -70,7 +70,7 @@ class WebClient {
         $headers = $this->parseResponseHeaders($headers_raw);
         $body = substr($result, $header_size);
 
-        return new WebClientResponse($body, $headers);;
+        return new WebClientResponse($body, $headers);
     }
 
     public function post($path, $payload) {

--- a/src/mediasilo/http/oauth/TwoLeggedOauthClient.php
+++ b/src/mediasilo/http/oauth/TwoLeggedOauthClient.php
@@ -3,6 +3,7 @@
 namespace mediasilo\http\oauth;
 
 use mediasilo\http\exception\NotFoundException;
+use mediasilo\http\WebClientResponse;
 use \OAuthStore;
 use \OAuthRequester;
 use \OAuthHttpException;
@@ -83,7 +84,7 @@ class TwoLeggedOauthClient {
         // $result is an array of the form: array ('code'=>int, 'headers'=>array(), 'body'=>string)
         try {
             $result = $request->doRequest();
-            return $result['body'];
+            return new WebClientResponse($result['body'], $result['headers']);
         } catch (OAuthHttpException $e) {
             throw new NotFoundException($e->getMessage(), null);
         }


### PR DESCRIPTION
Asset proxy now defers creation of role manager until a point when it's needed. Oauth client now returns a  WebClientResponse object wrapping response headers and body
