### PR TITLE
Bug Fix: Pagination Wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In the root of your project create a composer.json as follows. More info on gett
         }
     ],
     "require" : {
-        "mediasilo/phoenix-php-sdk": "0.6.3
+        "mediasilo/phoenix-php-sdk": "0.7.6
     }
 }
 ```

--- a/src/mediasilo/asset/AssetProxy.php
+++ b/src/mediasilo/asset/AssetProxy.php
@@ -4,17 +4,14 @@ namespace mediasilo\asset;
 
 use mediasilo\http\WebClient;
 use mediasilo\http\MediaSiloResourcePaths;
-use mediasilo\asset\Asset;
 use mediasilo\role\RoleManager;
-use mediasilo\http\exception\NotFoundException;
-use stdClass;
 
 class AssetProxy {
 
     private $webClient;
     private $roleManager;
 
-    public function __construct($webClient) {
+    public function __construct(WebClient $webClient) {
         $this->webClient = $webClient;
     }
 
@@ -93,28 +90,7 @@ class AssetProxy {
             }
         }
 
-
-        if ($wrapPagination) {
-            $response = new stdClass();
-            $response->paging = new stdClass();
-
-            try {
-                foreach($clientResponse->getHeaders() as $header) {
-                    $parts = explode(":", $header);
-                    if ($parts[0] == 'total-results') {
-                        $response->paging->total = intval($parts[1]);
-                    }
-                }
-            } catch (\Exception $e) {
-                $response->paging->total = 0;
-            }
-
-            $response->results = $assets;
-            return $response;
-
-        } else {
-            return $assets;
-        }
+        return $wrapPagination ? $clientResponse->buildPaginatedResponse($assets) : $assets;
     }
 
     /**
@@ -149,27 +125,7 @@ class AssetProxy {
             }
         }
 
-        if ($wrapPagination) {
-            $response = new stdClass();
-            $response->paging = new stdClass();
-
-            try {
-                foreach($clientResponse->getHeaders() as $header) {
-                    $parts = explode(":", $header);
-                    if ($parts[0] == 'total-results') {
-                        $response->paging->total = intval($parts[1]);
-                    }
-                }
-            } catch (\Exception $e) {
-                $response->paging->total = 0;
-            }
-
-            $response->results = $assets;
-            return $response;
-
-        } else {
-            return $assets;
-        }
+        return $wrapPagination ? $clientResponse->buildPaginatedResponse($assets) : $assets;
     }
 
     /**
@@ -205,27 +161,7 @@ class AssetProxy {
             }
         }
 
-        if ($wrapPagination) {
-            $response = new stdClass();
-            $response->paging = new stdClass();
-
-            try {
-                foreach($clientResponse->getHeaders() as $header) {
-                    $parts = explode(":", $header);
-                    if ($parts[0] == 'total-results') {
-                        $response->paging->total = intval($parts[1]);
-                    }
-                }
-            } catch (\Exception $e) {
-                $response->paging->total = 0;
-            }
-
-            $response->results = $assets;
-            return $response;
-
-        } else {
-            return $assets;
-        }
+        return $wrapPagination ? $clientResponse->buildPaginatedResponse($assets) : $assets;
     }
 
 
@@ -262,27 +198,7 @@ class AssetProxy {
             }
         }
 
-        if ($wrapPagination) {
-            $response = new stdClass();
-            $response->paging = new stdClass();
-
-            try {
-                foreach($clientResponse->getHeaders() as $header) {
-                    $parts = explode(":", $header);
-                    if ($parts[0] == 'total-results') {
-                        $response->paging->total = intval($parts[1]);
-                    }
-                }
-            } catch (\Exception $e) {
-                $response->paging->total = 0;
-            }
-
-            $response->results = $assets;
-            return $response;
-
-        } else {
-            return $assets;
-        }
+        return $wrapPagination ? $clientResponse->buildPaginatedResponse($assets) : $assets;
     }
 
 

--- a/src/mediasilo/http/WebClientResponse.php
+++ b/src/mediasilo/http/WebClientResponse.php
@@ -2,6 +2,9 @@
 
 namespace mediasilo\http;
 
+use Exception;
+use stdClass;
+
 class WebClientResponse {
 
     private $code;
@@ -62,4 +65,34 @@ class WebClientResponse {
     {
         return $this->code;
     }
+
+    /**
+     * @param $queryResults
+     * @return stdClass
+     */
+    public function buildPaginatedResponse($queryResults) {
+        $response = new stdClass();
+        $response->paging = new stdClass();
+
+        try {
+            foreach($this->getHeaders() as $header) {
+                $parts = explode(":", $header);
+                if ($parts[0] == 'total-results') {
+                    $response->paging->total = intval($parts[1]);
+                }
+            }
+
+            if (!isset($response->paging->total)) {
+                $headers = $this->getHeaders();
+                $response->paging->total = intval($headers['total-results']);
+            }
+
+        } catch (Exception $e) {
+            $response->paging->total = 0;
+        }
+
+        $response->results = $queryResults;
+        return $response;
+    }
+
 }

--- a/src/mediasilo/quicklink/QuickLinkProxy.php
+++ b/src/mediasilo/quicklink/QuickLinkProxy.php
@@ -7,14 +7,13 @@ use mediasilo\http\MediaSiloResourcePaths;
 use mediasilo\quicklink\analytics\AnalyticsEvent;
 use mediasilo\quicklink\analytics\AnalyzedQuickLink;
 use mediasilo\quicklink\analytics\QuickLinkAnalyticsProxy;
-use stdClass;
 
 class QuickLinkProxy {
 
     private $webClient;
     private $quicklinkAnalyticsProxy;
 
-    public function __construct($webClient) {
+    public function __construct(WebClient $webClient) {
         $this->webClient = $webClient;
         $this->quicklinkAnalyticsProxy = new QuickLinkAnalyticsProxy($webClient);
     }
@@ -96,23 +95,7 @@ class QuickLinkProxy {
             }
         }
 
-        if ($wrapPagination) {
-            $response = new stdClass();
-            $response->paging = new stdClass();
-
-            foreach($clientResponse->getHeaders() as $header) {
-                $parts = explode(":", $header);
-                if ($parts[0] == 'total-results') {
-                    $response->paging->total = intval($parts[1]);
-                }
-            }
-
-            $response->results = $quicklinks;
-            return $response;
-
-        } else {
-            return $quicklinks;
-        }
+        return $wrapPagination ? $clientResponse->buildPaginatedResponse($quicklinks) : $quicklinks;
     }
 
     /**


### PR DESCRIPTION
* Fixed a bug where API response headers were not being parsed correctly in PHP 5.6 (and possibly other versions);
* Put pagination wrapping functionality in a single location;
* Retained original method of parsing response headers for backward compatibility.